### PR TITLE
Fix stylistic rule rename and react-hooks peer dep (v5.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jchiam/eslint-config",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "my personal ESLint rules",
   "type": "module",
   "main": "recommended.js",
@@ -23,7 +23,7 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jest": "^29.0.0",
     "eslint-plugin-react": "^7.32.0",
-    "eslint-plugin-react-hooks": "^5.0.0"
+    "eslint-plugin-react-hooks": "^7.0.0"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-jest": {

--- a/recommended.js
+++ b/recommended.js
@@ -72,7 +72,7 @@ export default [
       '@stylistic/comma-style': 'error',
       '@stylistic/computed-property-spacing': 'error',
       '@stylistic/eol-last': 'error',
-      '@stylistic/func-call-spacing': 'error',
+      '@stylistic/function-call-spacing': 'error',
       '@stylistic/indent': ['error', 2, { SwitchCase: 1 }],
       '@stylistic/key-spacing': 'error',
       '@stylistic/keyword-spacing': 'error',


### PR DESCRIPTION
## Summary

- Rename \`@stylistic/func-call-spacing\` → \`@stylistic/function-call-spacing\` in \`recommended.js\` — the rule was renamed in \`@stylistic/eslint-plugin\` v5, causing ESLint to throw on startup
- Update \`eslint-plugin-react-hooks\` peer dependency from \`^5.0.0\` → \`^7.0.0\` to match the version used in development
- Bump package version to \`5.0.1\`

## Test plan

- [ ] Run \`npm run lint\` in a consuming project (e.g. \`react-three-state-checkbox\`) with this version installed — should complete without errors
- [ ] Confirm no \`func-call-spacing\` rule errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)