### PR TITLE
Fix missed package-lock.json updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jchiam/eslint-config",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jchiam/eslint-config",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dependencies": {
         "@eslint/js": "^9.0.0",
         "@stylistic/eslint-plugin": "^5.0.0",
@@ -25,7 +25,7 @@
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jest": "^29.0.0",
         "eslint-plugin-react": "^7.32.0",
-        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
         "typescript-eslint": "^8.0.0"
       },
       "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

- Updates `package-lock.json` to reflect the peer dependency change from #5 (`eslint-plugin-react-hooks` `^5.0.0` → `^7.0.0`) that was missed in that PR

## Test plan

- [ ] Confirm `package-lock.json` is consistent with `package.json` after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)