### PR TITLE
Make /react self-contained (v7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Architecture
 
 - **`recommended.js`** — the default/`main` export. Base config for any TypeScript project. Composes `@eslint/js` recommended, `typescript-eslint` recommended, `eslint-plugin-import-x` (recommended + typescript settings, re-registered under the `import` namespace so rules stay `import/...`; resolver settings use the `import-x/` prefix), and an opinionated rule block: TS rules, best-practice rules, ES6+ rules, and all formatting rules via `@stylistic/eslint-plugin`.
-- **`react.js`** — the `/react` subpath export. A **standalone increment**, not a superset: it does *not* re-include `recommended.js`. Consumers spread both (`[...jchiamConfig, ...jchiamReact]`). Adds `@eslint-react/eslint-plugin` recommended, `eslint-plugin-react-hooks`, and JSX stylistic rules.
+- **`react.js`** — the `/react` subpath export. **Self-contained**: it spreads `recommended.js` first, then adds `@eslint-react/eslint-plugin` recommended, `eslint-plugin-react-hooks`, and JSX stylistic rules. React consumers spread a single array (`[...jchiamReact]`); they must *not* also spread `recommended` or the base is included twice. The ordering invariant (base before the React layer) lives here, not in consumer config.
 
 ### Dependency boundaries (important when editing rules)
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ export default [...jchiamConfig];
 
 ```js
 // eslint.config.js — React + TypeScript project
-import jchiamConfig from '@jchiam/eslint-config';
+// The /react config is self-contained — it includes the base config, so spread
+// it alone. Do not also spread the base, or it will be included twice.
 import jchiamReact from '@jchiam/eslint-config/react';
 
-export default [...jchiamConfig, ...jchiamReact];
+export default [...jchiamReact];
 ```
 
 Override rules by appending a config object to the array:
@@ -63,11 +64,30 @@ export default [
 
 ### `react.js`
 
-Extends `recommended.js` intent with:
+Self-contained — includes everything in `recommended.js`, plus:
 - [`@eslint-react/eslint-plugin`](https://github.com/Rel1cx/eslint-react) recommended rules (bundled — no separate install needed)
 - [`eslint-plugin-react-hooks`](https://github.com/facebook/react) rules of hooks + exhaustive deps
 
+Spread it on its own (`[...jchiamReact]`); there is no need to also spread the base config.
+
 ## Breaking Changes
+
+### v6 to v7
+
+The `/react` config is now **self-contained** — it includes the base config, so React projects spread a single array instead of composing base + react themselves.
+
+```js
+// Before (v6)
+import jchiamConfig from '@jchiam/eslint-config';
+import jchiamReact from '@jchiam/eslint-config/react';
+export default [...jchiamConfig, ...jchiamReact];
+
+// After (v7)
+import jchiamReact from '@jchiam/eslint-config/react';
+export default [...jchiamReact];
+```
+
+Spreading both as before still "works" but includes the base config twice. Non-React projects are unaffected — keep using `recommended` as before.
 
 ### v5 to v6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jchiam/eslint-config",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "my personal ESLint rules",
   "type": "module",
   "main": "recommended.js",

--- a/react.js
+++ b/react.js
@@ -1,8 +1,14 @@
+import recommended from './recommended.js';
 import eslintReact from '@eslint-react/eslint-plugin';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import stylistic from '@stylistic/eslint-plugin';
 
+// Self-contained React + TypeScript config. It includes the base `recommended`
+// config, so consumers spread a single array (`[...jchiamReact]`) rather than
+// composing base + react themselves and having to get the order right.
+// recommended.js remains the standalone base for non-React projects.
 export default [
+  ...recommended,
   eslintReact.configs.recommended,
   {
     plugins: {

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -11,7 +11,6 @@ import react from '../react.js';
 // where a silent regression is both most likely and most invisible. Upstream
 // plugin defaults are not re-tested here.
 
-const combined = [...recommended, ...react];
 const linter = new Linter({ configType: 'flat' });
 
 // Fixtures carry incidental violations (eol-last, no-unused-vars, ...), so we
@@ -147,16 +146,24 @@ const fixtures = [
     fires: ['import/no-duplicates'],
   },
 
-  // React layer (spread after the base, as consumers do)
+  // React config is self-contained: it includes the base, so a base rule must
+  // still fire through react.js alone. This is the proof the increment was
+  // deepened — react owns the base + ordering, consumers spread one array.
+  {
+    name: 'react config includes the base (array-type fires)',
+    config: react, filename: 'C.tsx',
+    code: 'const x: number[] = [];\nconsole.log(x);\n',
+    fires: ['@typescript-eslint/array-type'],
+  },
   {
     name: 'react-hooks flags conditional hook calls',
-    config: combined, filename: 'C.tsx',
+    config: react, filename: 'C.tsx',
     code: 'export function C() {\n  if (true) { useState(); }\n  return null;\n}\n',
     fires: ['react-hooks/rules-of-hooks'],
   },
   {
     name: 'jsx-quotes is enforced',
-    config: combined, filename: 'C.tsx',
+    config: react, filename: 'C.tsx',
     code: "export const C = () => <div className='a' />;\n",
     fires: ['@stylistic/jsx-quotes'],
   },


### PR DESCRIPTION
## Summary
- **Breaking (v7.0.0):** the `/react` config now includes the base `recommended` config and owns the base-before-react ordering. React consumers spread a single array (`[...jchiamReact]`) instead of composing base + react themselves.
- Deepens a previously shallow increment: the ordering invariant moves out of every consumer's `eslint.config.js` and into one module (locality). Non-React projects are unaffected — `recommended` stays the standalone base.
- Adds a fixture asserting a *base* rule (`@typescript-eslint/array-type`) fires through `react.js` alone — the proof the base is bundled. Verified it bites: under the old increment-only form, that rule does not fire.
- Updates README (usage + v6→v7 Breaking Changes) and CLAUDE.md architecture notes.

## Test plan
- [x] CI green on Node 20/22/24 (`npm ci && npm test`)
- [x] `npm test` passes locally — 22/22 fixtures
- [x] `react.js` lints clean code without a duplicate-plugin error (9 config objects)
- [x] Confirm a React+TS consumer using `[...jchiamReact]` alone gets both base rules (e.g. `array-type`) and React rules (`rules-of-hooks`, `jsx-quotes`)

> Note: 6.0.0 is already published; this lands as 7.0.0. Cut the GitHub Release **after** merge to trigger the provenance publish — do not republish 6.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)